### PR TITLE
Added missing console bootstrap

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Console application bootstrap file
+ */
+use ZF\Console\Application;
+
+chdir(dirname(__DIR__));
+require 'vendor/autoload.php';
+
+/**
+ * Self-called anonymous function that creates its own scope and keep the global namespace clean.
+ */
+call_user_func(function () {
+    /** @var \Interop\Container\ContainerInterface $container */
+    $container = require 'config/container.php';
+
+    /** @var Application $app */
+    $app = $container->get(Application::class);
+
+    $exit = $app->run();
+    exit($exit);
+});


### PR DESCRIPTION
Added missing console bootstrap from dotkernel/dot-frontend as documented

This file's role is similar to public/index.php from dotkernel/frontend

source: `https://github.com/dotkernel/frontend/blob/master/bin/console.php`